### PR TITLE
Add validation for user creation in mock REST app

### DIFF
--- a/mock-app/app.js.txt
+++ b/mock-app/app.js.txt
@@ -9,9 +9,20 @@ let mockDB = {};
 
 app.post('/createUser', (req, res) => {
   const { id, name, department } = req.body;
+
+  // Validate required fields
+  if (!id || !name || !department) {
+    return res.status(400).send({ error: 'Missing required fields' });
+  }
+
+  // Prevent accidental overwrite when the user already exists
+  if (mockDB[id]) {
+    return res.status(409).send({ error: 'User already exists' });
+  }
+
   mockDB[id] = { name, department, status: 'active' };
   console.log(`User created: ${id}`);
-  res.send({ status: 'success', id });
+  res.status(201).send({ status: 'success', id });
 });
 
 app.put('/updateUser/:id', (req, res) => {


### PR DESCRIPTION
## Summary
- validate required fields in `createUser` endpoint
- reject duplicate user IDs with HTTP 409

## Testing
- `curl -s -X POST http://localhost:3000/createUser -H 'Content-Type: application/json' -d '{"id":"u1","name":"Alice","department":"Engineering"}'`
- `curl -s -o - -w '%{http_code}' -X POST http://localhost:3000/createUser -H 'Content-Type: application/json' -d '{"id":"u1","name":"Alice","department":"Engineering"}'`
- `curl -s -o - -w '%{http_code}' -X POST http://localhost:3000/createUser -H 'Content-Type: application/json' -d '{"name":"Bob","department":"Finance"}'`


------
https://chatgpt.com/codex/tasks/task_e_6894d6c772308332adc604b0f2a75fd1